### PR TITLE
Fix dns uncaught exception

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -12,26 +12,30 @@ var httpsProxyAgent = require('https-proxy-agent');
 
 function _responseHandler(req) {
   return new Promise(function(resolve, reject) {
-    req.on('response', function(res) {
-      var resp = '';
-      res.setEncoding('utf8');
-      res.on('data', function(chunk) {
-        resp += chunk;
-      });
-      res.on('end', function() {
-        try {
-          logger.log('info', resp);
-          resp = JSON.parse(resp);
-          if (resp.object === 'error') {
-            reject(resp);
-          } else {
-            resolve(resp);
+    req
+      .on('response', function(res) {
+        var resp = '';
+        res.setEncoding('utf8');
+        res.on('data', function(chunk) {
+          resp += chunk;
+        });
+        res.on('end', function() {
+          try {
+            logger.log('info', resp);
+            resp = JSON.parse(resp);
+            if (resp.object === 'error') {
+              reject(resp);
+            } else {
+              resolve(resp);
+            }
+          } catch (err) {
+            reject(err);
           }
-        } catch (err) {
-          reject(err);
-        }
+        });
+      })
+      .on('error', function(err) {
+        reject(err);
       });
-    });
   });
 }
 


### PR DESCRIPTION
Fix case receive uncaught exception error when cannot call dns server

ex:
```js
Error: getaddrinfo ENOTFOUND api.omise.co api.omise.co:443
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:57:26)
```
